### PR TITLE
認証フォームUIの実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,12 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.1.1",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hook-form": "^7.58.1",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -223,6 +226,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.1.1.tgz",
+      "integrity": "sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -970,6 +985,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -5071,6 +5092,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6130,6 +6167,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.58.1",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,30 @@
+export default function DashboardPage() {
+  return (
+    <div className="min-h-screen py-8">  {/* bg-gray-50を削除 */}
+      <div className="max-w-4xl mx-auto px-4">
+        <div className="bg-white rounded-lg shadow p-6">
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">
+            ダッシュボード
+          </h1>
+          <p className="text-gray-600 mb-6">
+            ログインに成功しました！これは一時的なダッシュボードページです。
+          </p>
+
+          {/* 以下はそのまま */}
+          <div className="bg-green-50 border border-green-200 rounded-md p-4">
+            {/* ... */}
+          </div>
+
+          <div className="mt-6">
+            <a 
+              href="/login"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              ログインページに戻る
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,3 +24,112 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* 認証フォーム用の統一スタイル */
+.auth-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* 背景はbodyから継承 */
+}
+
+.auth-form {
+  max-width: 28rem;
+  width: 100%;
+  background-color: white;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  margin: 1rem;
+}
+
+.auth-form h2 {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 1.875rem;
+  font-weight: 800;
+  color: #111827;
+}
+
+.auth-form-content {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-input-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-input-field label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+
+.auth-input-field input {
+  margin-top: 0.25rem;
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  outline: none;
+}
+
+.auth-input-field input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 1px #6366f1;
+}
+
+.auth-error {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #dc2626;
+}
+
+.auth-api-error {
+  font-size: 0.875rem;
+  color: #dc2626;
+  text-align: center;
+}
+
+.auth-button {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 0.375rem;
+  color: white;
+  background-color: #6366f1;
+  cursor: pointer;
+  outline: none;
+}
+
+.auth-button:hover:not(:disabled) {
+  background-color: #4f46e5;
+}
+
+.auth-button:focus {
+  box-shadow: 0 0 0 2px #6366f1, 0 0 0 4px rgba(99, 102, 241, 0.1);
+}
+
+.auth-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,8 +1,105 @@
-export default function LoginPlaceholder() {
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { loginSchema, type LoginFormData } from '@/lib/validation'
+import { useState } from 'react'
+
+export default function LoginPage() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [apiError, setApiError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginSchema)
+  })
+
+  const onSubmit = async (data: LoginFormData) => {
+    setIsLoading(true)
+    setApiError(null)
+
+    try {
+      const response = await fetch('http://localhost:3001/api/v1/auth/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data)
+      })
+
+      if (response.ok) {
+        const result = await response.json()
+        console.log('ログイン成功:', result)
+        // TODO: JWT保存とダッシュボードリダイレクト
+        alert('ログインに成功しました！')
+      } else {
+        const error = await response.json()
+        setApiError(error.message || 'ログインに失敗しました')
+      }
+    } catch (error) {
+      setApiError('ネットワークエラーが発生しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return (
-    <section>
-      <h1 className="text-2xl font-bold">ログインページ（プレースホルダー）</h1>
-      <p className="mt-2">ここにログインフォームを実装します。</p>
-    </section>
+    <div className="auth-container">
+      <div className="auth-form">
+        <div>
+          <h2>ログイン</h2>
+        </div>
+        <form className="auth-form-content" onSubmit={handleSubmit(onSubmit)}>
+          <div className="auth-input-group">
+            {/* メールアドレス */}
+            <div className="auth-input-field">
+              <label htmlFor="email">メールアドレス</label>
+              <input
+                {...register('email')}
+                type="email"
+                placeholder="example@email.com"
+              />
+              {errors.email && (
+                <p className="auth-error">{errors.email.message}</p>
+              )}
+            </div>
+
+            {/* パスワード */}
+            <div className="auth-input-field">
+              <label htmlFor="password">パスワード</label>
+              <input
+                {...register('password')}
+                type="password"
+                placeholder="6文字以上"
+              />
+              {errors.password && (
+                <p className="auth-error">{errors.password.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* APIエラー表示 */}
+          {apiError && (
+            <div className="auth-api-error">
+              {apiError}
+            </div>
+          )}
+
+          {/* 送信ボタン */}
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="auth-button"
+            >
+              {isLoading ? 'ログイン中...' : 'ログイン'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
         const result = await response.json()
         console.log('ログイン成功:', result)
         // TODO: JWT保存とダッシュボードリダイレクト
-        alert('ログインに成功しました！')
+        window.location.href = '/dashboard'
       } else {
         const error = await response.json()
         setApiError(error.message || 'ログインに失敗しました')

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -34,7 +34,7 @@ export default function SignupPage() {
         const result = await response.json()
         console.log('新規登録成功:', result)
         // TODO: JWT保存とダッシュボードリダイレクト
-        alert('新規登録に成功しました！')
+        window.location.href = '/dashboard'
       } else {
         const error = await response.json()
         setApiError(error.message || '新規登録に失敗しました')

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,8 +1,118 @@
-export default function Signup() {
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { registerSchema, type RegisterFormData } from '@/lib/validation'
+import { useState } from 'react'
+
+export default function SignupPage() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [apiError, setApiError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<RegisterFormData>({
+    resolver: zodResolver(registerSchema)
+  })
+
+  const onSubmit = async (data: RegisterFormData) => {
+    setIsLoading(true)
+    setApiError(null)
+
+    try {
+      const response = await fetch('http://localhost:3001/api/v1/auth/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ user: data })
+      })
+
+      if (response.ok) {
+        const result = await response.json()
+        console.log('新規登録成功:', result)
+        // TODO: JWT保存とダッシュボードリダイレクト
+        alert('新規登録に成功しました！')
+      } else {
+        const error = await response.json()
+        setApiError(error.message || '新規登録に失敗しました')
+      }
+    } catch (error) {
+      setApiError('ネットワークエラーが発生しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return (
-    <section>
-      <h1 className="text-2xl font-bold">新規登録ページ（プレースホルダー）</h1>
-      <p className="mt-2">ここに新規登録を実装します。</p>
-    </section>
+    <div className="auth-container">
+      <div className="auth-form">
+        <div>
+          <h2>新規登録</h2>
+        </div>
+        <form className="auth-form-content" onSubmit={handleSubmit(onSubmit)}>
+          <div className="auth-input-group">
+            {/* 名前 */}
+            <div className="auth-input-field">
+              <label htmlFor="name">名前</label>
+              <input
+                {...register('name')}
+                type="text"
+                placeholder="山田太郎"
+              />
+              {errors.name && (
+                <p className="auth-error">{errors.name.message}</p>
+              )}
+            </div>
+
+            {/* メールアドレス */}
+            <div className="auth-input-field">
+              <label htmlFor="email">メールアドレス</label>
+              <input
+                {...register('email')}
+                type="email"
+                placeholder="example@email.com"
+              />
+              {errors.email && (
+                <p className="auth-error">{errors.email.message}</p>
+              )}
+            </div>
+
+            {/* パスワード */}
+            <div className="auth-input-field">
+              <label htmlFor="password">パスワード</label>
+              <input
+                {...register('password')}
+                type="password"
+                placeholder="6文字以上"
+              />
+              {errors.password && (
+                <p className="auth-error">{errors.password.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* APIエラー表示 */}
+          {apiError && (
+            <div className="auth-api-error">
+              {apiError}
+            </div>
+          )}
+
+          {/* 送信ボタン */}
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="auth-button"
+            >
+              {isLoading ? '登録中...' : '新規登録'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+// ログイン用スキーマ
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください')
+    .email('正しいメールアドレスを入力してください'),
+  password: z
+    .string()
+    .min(6, 'パスワードは6文字以上で入力してください')
+})
+
+// 新規登録用スキーマ
+export const registerSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'メールアドレスを入力してください')
+    .email('正しいメールアドレスを入力してください'),
+  password: z
+    .string()
+    .min(6, 'パスワードは6文字以上で入力してください'),
+  name: z
+    .string()
+    .min(1, '名前を入力してください')
+})
+
+export type LoginFormData = z.infer<typeof loginSchema>
+export type RegisterFormData = z.infer<typeof registerSchema>


### PR DESCRIPTION
### 概要
<!-- このPRで何を変更したかを簡潔に -->
新規登録およびログインの認証フォームのUIを実装しました

### 変更内容
<!-- 具体的な変更点を箇条書きで -->
- 新規登録ページの認証フォーム実装
- ログインページの認証フォーム実装
- ログイン後のダッシュボード（確認用）

### 動作確認
<!-- スクリーンショットや動作確認の結果 -->
<img width="925" alt="スクリーンショット 2025-06-24 3 40 08" src="https://github.com/user-attachments/assets/5f183efc-7ceb-4ac4-8f3f-b2229fbf6299" />


### 確認依頼
<!-- レビュー時に確認してほしいポイント -->
- [ ] ログインフォームで正常なデータでログインできるか
- [ ] ログインフォームで誤ったユーザー情報でバリデーションエラーが出るか
- [ ] 新規登録で正常なデータで新規登録できるか
- [ ] 新規登録フォームで誤ったユーザー情報でバリデーションエラー出るか
- [ ] 正常にログインできた場合にダッシュボード画面に遷移するか

### 補足
<!-- レビュアーに伝えたいことがあれば -->
ダッシュボードはログイン確認のために仮で用意した画面なので、ログイン後のリダイレクト先になる画面の実装時に置き換えます。

### 関連Issue
<!-- 関連するIssueがあれば -->
#67 
### CloseしたいIssue
Close #67 