### PR TITLE
AuthContext/useAuth・useApi・ログアウト機能を実装

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,15 @@
+'use client'
+
+import { useAuth } from '@/contexts/AuthContext'
+
 export default function DashboardPage() {
+  const { user, logout } = useAuth()
+
+  const handleLogout = async () => {
+    logout()
+    window.location.href = '/login'
+  }
+
   return (
     <div className="min-h-screen py-8">  {/* bg-gray-50を削除 */}
       <div className="max-w-4xl mx-auto px-4">
@@ -6,22 +17,51 @@ export default function DashboardPage() {
           <h1 className="text-3xl font-bold text-gray-900 mb-4">
             ダッシュボード
           </h1>
+
+          {user && (
+            <div className="mb-6">
+              <p className="text-gray-600">
+                ようこそ、{user.name}さん！（{user.email}）
+              </p>
+            </div>
+          )}
+
           <p className="text-gray-600 mb-6">
-            ログインに成功しました！これは一時的なダッシュボードページです。
+            ログインに成功しました！現在認証状態です。
           </p>
 
-          {/* 以下はそのまま */}
-          <div className="bg-green-50 border border-green-200 rounded-md p-4">
-            {/* ... */}
+          <div className="bg-green-50 border border-green-200 rounded-md p-4 mb-6">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-green-800">
+                  JWT管理機能が動作中
+                </h3>
+                <div className="mt-2 text-sm text-green-700">
+                  <p>ページを更新しても認証状態が維持されます。</p>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="mt-6">
-            <a 
+            <a
               href="/login"
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
             >
               ログインページに戻る
             </a>
+
+            <button
+              onClick={handleLogout}  {/* handlelogout → handleLogout */}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+            >
+              ログアウト
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,13 +1,29 @@
 'use client'
 
 import { useAuth } from '@/contexts/AuthContext'
+import { useApi } from '@/hooks/useApi'
+import { useState } from 'react'
 
 export default function DashboardPage() {
-  const { user, logout } = useAuth()
+  const { user, logout: authLogout } = useAuth()
+  const { logout: apiLogout } = useApi()
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   const handleLogout = async () => {
-    logout()
-    window.location.href = '/login'
+    setIsLoggingOut(true)
+
+    try {
+      // バックエンドAPIでログアウト
+      await apiLogout()
+      console.log('サーバーサイドログアウト成功')
+    } catch (error) {
+      console.error('サーバーサイドログアウトエラー:', error)
+      // エラーが発生してもローカルのログアウトは実行
+    } finally {
+      // ローカルの認証状態をクリア
+      authLogout()
+      window.location.href = '/login'
+    }
   }
 
   return (
@@ -49,18 +65,12 @@ export default function DashboardPage() {
           </div>
 
           <div className="mt-6">
-            <a
-              href="/login"
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700"
-            >
-              ログインページに戻る
-            </a>
-
             <button
-              onClick={handleLogout}  {/* handlelogout → handleLogout */}
-              className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
             >
-              ログアウト
+              {isLoggingOut ? 'ログアウト中...' : 'ログアウト'}
             </button>
           </div>
         </div>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 
 import PublicHeader from '@/components/layout/PublicHeader'
 import PublicFooter from '@/components/layout/PublicFooter'
+import { AuthProvider } from '@/contexts/AuthContext'
 
 export const metadata = {
   title: 'ベジファミリー',
@@ -11,11 +12,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ja">
       <body className="min-h-screen flex flex-col">
-        <PublicHeader />
-        <main className="flex-1 container mx-auto p-6">
-          {children}
-        </main>
-        <PublicFooter />
+        <AuthProvider>
+          <PublicHeader />
+          <main className="flex-1 container mx-auto p-6">
+            {children}
+          </main>
+          <PublicFooter />
+        </AuthProvider>
       </body>
     </html>
   )

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -4,11 +4,14 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loginSchema, type LoginFormData } from '@/lib/validation'
 import { apiCall } from '@/lib/api'
+import { useAuth } from '@/contexts/AuthContext'
 import { useState } from 'react'
 
 export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+
+  const { login } = useAuth()
 
   const {
     register,
@@ -31,6 +34,9 @@ export default function LoginPage() {
       if (response.ok) {
         const result = await response.json()
         console.log('ログイン成功:', result)
+
+        // useAuthのlogin関数を使ってJWT保存
+        login(result.token, result.user)
         // TODO: JWT保存とダッシュボードリダイレクト
         window.location.href = '/dashboard'
       } else {

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -4,11 +4,14 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { registerSchema, type RegisterFormData } from '@/lib/validation'
 import { apiCall } from '@/lib/api'
+import { useAuth } from '@/contexts/AuthContext'
 import { useState } from 'react'
 
 export default function SignupPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
+
+  const { login } = useAuth()
 
   const {
     register,
@@ -31,6 +34,9 @@ export default function SignupPage() {
       if (response.ok) {
         const result = await response.json()
         console.log('新規登録成功:', result)
+
+        // useAuthのlogin関数を使ってJWT保存
+        login(result.token, result.user)
         // TODO: JWT保存とダッシュボードリダイレクト
         window.location.href = '/dashboard'
       } else {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -36,7 +36,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         setToken(savedToken)
         setUser(JSON.parse(savedUser))
-      } catch (error) {
+      } catch {
         // パース失敗時はクリア
         localStorage.removeItem('auth_token')
         localStorage.removeItem('auth_user')

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+
+// ユーザー情報の型定義
+interface User {
+  id: number
+  email: string
+  name: string
+}
+
+// 認証コンテキストの型定義
+interface AuthContextType {
+  user: User | null
+  token: string | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  login: (token: string, user: User) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+// AuthProvider コンポーネント
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // ページ読み込み時にlocalStorageからトークンを復元
+  useEffect(() => {
+    const savedToken = localStorage.getItem('auth_token')
+    const savedUser = localStorage.getItem('auth_user')
+
+    if (savedToken && savedUser) {
+      try {
+        setToken(savedToken)
+        setUser(JSON.parse(savedUser))
+      } catch (error) {
+        // パース失敗時はクリア
+        localStorage.removeItem('auth_token')
+        localStorage.removeItem('auth_user')
+      }
+    }
+    setIsLoading(false)
+  }, [])
+
+  // ログイン関数
+  const login = (newToken: string, newUser: User) => {
+    setToken(newToken)
+    setUser(newUser)
+    localStorage.setItem('auth_token', newToken)
+    localStorage.setItem('auth_user', JSON.stringify(newUser))
+  }
+
+  // ログアウト関数
+  const logout = () => {
+    setToken(null)
+    setUser(null)
+    localStorage.removeItem('auth_token')
+    localStorage.removeItem('auth_user')
+  }
+
+  const value = {
+    user,
+    token,
+    isAuthenticated: !!user,
+    isLoading,
+    login,
+    logout
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+// useAuth カスタムフック
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,41 @@
+import { useAuth } from '@/contexts/AuthContext'
+import { API_BASE_URL } from '@/lib/api'
+
+// 認証付きAPI呼び出し用のカスタムフック
+export function useApi() {
+  const { token } = useAuth()
+
+  // 認証付きAPI呼び出し関数
+  const authenticatedCall = async (endpoint: string, options: RequestInit = {}) => {
+    const url = `${API_BASE_URL}${endpoint}`
+    
+    const defaultHeaders = {
+      'Content-Type': 'application/json',
+      ...(token && { 'Authorization': `Bearer ${token}` })
+    }
+
+    return fetch(url, {
+      ...options,
+      headers: {
+        ...defaultHeaders,
+        ...options.headers,
+      },
+    })
+  }
+
+  // ログアウトAPI専用関数
+  const logout = async () => {
+    if (!token) {
+      throw new Error('No token available')
+    }
+
+    return authenticatedCall('/api/v1/auth/logout', {
+      method: 'DELETE'
+    })
+  }
+
+  return {
+    authenticatedCall,
+    logout
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,3 +19,28 @@ export const apiCall = async (endpoint: string, options: RequestInit = {}) => {
     },
   })
 }
+
+// 認証付きAPI呼び出し関数
+export const authenticatedApiCall = async (endpoint: string, token: string, options: RequestInit = {}) => {
+  const url = `${API_BASE_URL}${endpoint}`
+
+  const defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  }
+
+  return fetch(url, {
+    ...options,
+    headers: {
+      ...defaultHeaders,
+      ...options.headers,
+    },
+  })
+}
+
+// ログアウトAPI呼び出し関数
+export const logoutApi = async (token: string) => {
+  return authenticatedApiCall('/api/v1/auth/logout', token, {
+    method: 'DELETE'
+  })
+}


### PR DESCRIPTION
### 概要
<!-- このPRで何を変更したかを簡潔に -->
AuthContextとuseAuthフックでJWTをlocalStorageに保存・認証状態を維持し、useApiフックで全APIに自動でJWTを付与する機能を実装しました。
また、完全なログアウトフローを実装しました。
### 変更内容
<!-- 具体的な変更点を箇条書きで -->
- JWT管理: localStorage での安全な保存・取得
- 認証状態管理: ページ更新後も維持
- API自動認証: すべてのAPI呼び出しに自動でJWT付与
- ログアウト機能: サーバー・ローカル両方の認証クリア

### 動作確認
<!-- スクリーンショットや動作確認の結果 -->

### 補足
<!-- レビュアーに伝えたいことがあれば -->

### 関連Issue
<!-- 関連するIssueがあれば -->
#68 
### CloseしたいIssue
Close #68 