### PR TITLE
Feature/post crud

### DIFF
--- a/backend/app/controllers/api/v1/categories_controller.rb
+++ b/backend/app/controllers/api/v1/categories_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::CategoriesController < ApplicationController
+  skip_before_action :authenticate_request, only: [:index]
+
+  def index
+    begin
+      categories = Category.all.order(:name)
+      
+      categories_data = categories.map do |category|
+        {
+          id: category.id,
+          name: category.name
+        }
+      end
+
+      render json: {
+        categories: categories_data
+      }
+    rescue => e
+      Rails.logger.error "Error in CategoriesController#index: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      render json: {
+        error: "カテゴリの取得に失敗しました"
+      }, status: :internal_server_error
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::PostsController < ApplicationController
   skip_before_action :authenticate_request, only: [ :index ]
+  before_action :set_post, only: [:show, :update, :destroy]
+  
   def index
     begin
       page = params[:page]&.to_i || 1
@@ -57,5 +59,130 @@ class Api::V1::PostsController < ApplicationController
         }
       }
     end
+  end
+
+  def create
+    begin
+      @post = current_user.posts.build(post_params)
+      
+      if @post.save
+        render json: {
+          post: {
+            id: @post.id,
+            title: @post.title,
+            content: @post.content,
+            destination_type: @post.destination_type,
+            created_at: @post.created_at,
+            updated_at: @post.updated_at,
+            user: {
+              id: @post.user.id,
+              name: @post.user.name
+            },
+            growth_record: {
+              id: @post.growth_record.id,
+              record_name: @post.growth_record.record_name,
+              plant: {
+                id: @post.growth_record.plant.id,
+                name: @post.growth_record.plant.name
+              }
+            },
+            category: {
+              id: @post.category.id,
+              name: @post.category.name
+            }
+          }
+        }, status: :created
+      else
+        render json: {
+          error: "投稿の作成に失敗しました",
+          details: @post.errors.full_messages
+        }, status: :unprocessable_entity
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      render json: {
+        error: "指定された成長記録またはカテゴリが見つかりません"
+      }, status: :not_found
+    rescue => e
+      Rails.logger.error "Error in PostsController#create: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      render json: {
+        error: "投稿の作成に失敗しました"
+      }, status: :internal_server_error
+    end
+  end
+
+  def update
+    begin
+      if @post.update(post_params)
+        render json: {
+          post: {
+            id: @post.id,
+            title: @post.title,
+            content: @post.content,
+            destination_type: @post.destination_type,
+            created_at: @post.created_at,
+            updated_at: @post.updated_at,
+            user: {
+              id: @post.user.id,
+              name: @post.user.name
+            },
+            growth_record: {
+              id: @post.growth_record.id,
+              record_name: @post.growth_record.record_name,
+              plant: {
+                id: @post.growth_record.plant.id,
+                name: @post.growth_record.plant.name
+              }
+            },
+            category: {
+              id: @post.category.id,
+              name: @post.category.name
+            }
+          }
+        }
+      else
+        render json: {
+          error: "投稿の更新に失敗しました",
+          details: @post.errors.full_messages
+        }, status: :unprocessable_entity
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      render json: {
+        error: "指定された成長記録またはカテゴリが見つかりません"
+      }, status: :not_found
+    rescue => e
+      Rails.logger.error "Error in PostsController#update: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      render json: {
+        error: "投稿の更新に失敗しました"
+      }, status: :internal_server_error
+    end
+  end
+
+  def destroy
+    begin
+      @post.destroy
+      render json: { message: "投稿を削除しました" }
+    rescue => e
+      Rails.logger.error "Error in PostsController#destroy: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      render json: {
+        error: "投稿の削除に失敗しました"
+      }, status: :internal_server_error
+    end
+  end
+
+  private
+
+  def set_post
+    @post = current_user.posts.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: {
+      error: "投稿が見つかりません"
+    }, status: :not_found
+  end
+
+  def post_params
+    params.require(:post).permit(:title, :content, :growth_record_id, :category_id, :destination_type)
   end
 end

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::PostsController < ApplicationController
   skip_before_action :authenticate_request, only: [ :index ]
-  before_action :set_post, only: [:show, :update, :destroy]
+  before_action :set_post, only: [:update, :destroy]
   
   def index
     begin
@@ -23,11 +23,15 @@ class Api::V1::PostsController < ApplicationController
           id: post.user.id,
           name: post.user.name
         },
-        category: {
+      }
+      
+      # カテゴリがある場合のみ追加
+      if post.category
+        post_data[:category] = {
           id: post.category.id,
           name: post.category.name
         }
-      }
+      end
       
       # 成長記録がある場合のみ追加
       if post.growth_record
@@ -83,12 +87,16 @@ class Api::V1::PostsController < ApplicationController
           user: {
             id: @post.user.id,
             name: @post.user.name
-          },
-          category: {
+          }
+        }
+        
+        # カテゴリがある場合のみ追加
+        if @post.category
+          post_response[:category] = {
             id: @post.category.id,
             name: @post.category.name
           }
-        }
+        end
         
         # 成長記録がある場合のみ追加
         if @post.growth_record
@@ -135,12 +143,16 @@ class Api::V1::PostsController < ApplicationController
           user: {
             id: @post.user.id,
             name: @post.user.name
-          },
-          category: {
+          }
+        }
+        
+        # カテゴリがある場合のみ追加
+        if @post.category
+          post_response[:category] = {
             id: @post.category.id,
             name: @post.category.name
           }
-        }
+        end
         
         # 成長記録がある場合のみ追加
         if @post.growth_record

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :growth_record, optional: true
-  belongs_to :category
+  belongs_to :category, optional: true
 
   validates :title, presence: true
   validates :content, presence: true

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -1,17 +1,18 @@
 class Post < ApplicationRecord
   belongs_to :user
-  belongs_to :growth_record
+  belongs_to :growth_record, optional: true
   belongs_to :category
 
   validates :title, presence: true
   validates :content, presence: true
-  validates :destination_type, presence: true
+  validates :post_type, presence: true
 
-  enum destination_type: {
-    public_post: 0,
-    friends_only: 1,
-    private_post: 2
+  enum post_type: {
+    growth_record_post: 0,
+    general_post: 1
   }
 
-  scope :timeline, -> { where(destination_type: :public_post).includes(:user, :category, growth_record: :plant).order(created_at: :desc) }
+  scope :timeline, -> { includes(:user, :category, growth_record: [:plant]).order(created_at: :desc) }
+  scope :growth_record_posts, -> { where(post_type: :growth_record_post) }
+  scope :general_posts, -> { where(post_type: :general_post) }
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,13 +8,16 @@ Rails.application.routes.draw do
       delete "auth/logout", to: "auth#logout"
 
       # タイムライン関連API
-      resources :posts, only: [ :index ]
+      resources :posts, only: [ :index, :create, :update, :destroy ]
 
       # 成長記録関連API
       resources :growth_records, only: [ :index, :show, :create, :update, :destroy ]
 
       # 植物関連API
       resources :plants, only: [ :index ]
+
+      # カテゴリ関連API
+      resources :categories, only: [ :index ]
     end
 
     get "health_check", to: "health_check#index"

--- a/backend/db/migrate/20250716151500_update_posts_for_new_post_type.rb
+++ b/backend/db/migrate/20250716151500_update_posts_for_new_post_type.rb
@@ -1,0 +1,33 @@
+class UpdatePostsForNewPostType < ActiveRecord::Migration[7.2]
+  def up
+    # destination_typeカラムをpost_typeに変更
+    rename_column :posts, :destination_type, :post_type
+    
+    # 既存データを新しいenumに変換
+    # public_post(0) -> growth_record_post(0)
+    # friends_only(1) -> general_post(1) 
+    # private_post(2) -> general_post(1)
+    execute <<-SQL
+      UPDATE posts 
+      SET post_type = CASE 
+        WHEN post_type = 0 THEN 0
+        WHEN post_type = 1 THEN 1
+        WHEN post_type = 2 THEN 1
+        ELSE 0
+      END
+    SQL
+    
+    # growth_record_idをnull許可に変更
+    change_column_null :posts, :growth_record_id, true
+  end
+
+  def down
+    # 元に戻す処理
+    change_column_null :posts, :growth_record_id, false
+    
+    # データを元のenumに戻す（簡易的に全てpublic_postに）
+    execute "UPDATE posts SET post_type = 0"
+    
+    rename_column :posts, :post_type, :destination_type
+  end
+end

--- a/backend/db/migrate/20250716151501_change_category_id_to_optional_in_posts.rb
+++ b/backend/db/migrate/20250716151501_change_category_id_to_optional_in_posts.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryIdToOptionalInPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :category_id, true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_15_111017) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_16_151501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,11 +100,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_15_111017) do
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "growth_record_id", null: false
-    t.bigint "category_id", null: false
+    t.bigint "growth_record_id"
+    t.bigint "category_id"
     t.string "title"
     t.text "content"
-    t.integer "destination_type"
+    t.integer "post_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_posts_on_category_id"

--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import CreateGrowthRecordModal from './CreateGrowthRecordModal'
 import DeleteConfirmDialog from './DeleteConfirmDialog'
+import CreatePostModal from '../posts/CreatePostModal'
 import { API_BASE_URL } from '@/lib/api'
 
 interface GrowthRecord {
@@ -48,6 +49,7 @@ export default function GrowthRecordDetail({ id }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState(false)
 
   const fetchGrowthRecord = useCallback(async () => {
     try {
@@ -92,6 +94,11 @@ export default function GrowthRecordDetail({ id }: Props) {
   const handleDeleteSuccess = () => {
     // 削除成功時に一覧ページに戻る
     router.push('/growth-records')
+  }
+
+  const handleCreatePostSuccess = () => {
+    // 投稿作成成功時に詳細情報を再取得
+    fetchGrowthRecord()
   }
 
   const getStatusText = (status: string | null) => {
@@ -246,9 +253,17 @@ export default function GrowthRecordDetail({ id }: Props) {
 
       {/* 関連投稿 */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          関連投稿 ({posts.length}件)
-        </h2>
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            関連投稿 ({posts.length}件)
+          </h2>
+          <button
+            onClick={() => setIsCreatePostModalOpen(true)}
+            className="px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-md transition-colors"
+          >
+            ＋ 投稿を作成
+          </button>
+        </div>
         
         {posts.length === 0 ? (
           <div className="text-center py-8">
@@ -305,6 +320,14 @@ export default function GrowthRecordDetail({ id }: Props) {
           }}
         />
       )}
+
+      {/* 投稿作成モーダル */}
+      <CreatePostModal
+        isOpen={isCreatePostModalOpen}
+        onClose={() => setIsCreatePostModalOpen(false)}
+        onSuccess={handleCreatePostSuccess}
+        preselectedGrowthRecordId={growthRecord?.id}
+      />
     </div>
   )
 }

--- a/frontend/src/components/layout/AuthenticatedFooter.tsx
+++ b/frontend/src/components/layout/AuthenticatedFooter.tsx
@@ -21,14 +21,6 @@ export default function AuthenticatedFooter() {
             <span className="text-xs">ベジログ</span>
           </Link>
           
-          {/* 新規投稿 */}
-          <Link href="/post/new" className="flex flex-col items-center space-y-1">
-            <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clipRule="evenodd" />
-            </svg>
-            <span className="text-xs">新規投稿</span>
-          </Link>
-          
           {/* 育て方指南 */}
           <Link href="/guides" className="flex flex-col items-center space-y-1">
             <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -1,0 +1,364 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { API_BASE_URL } from '@/lib/api'
+
+interface GrowthRecord {
+  id: number
+  record_name: string
+  plant: {
+    id: number
+    name: string
+  }
+}
+
+interface Category {
+  id: number
+  name: string
+}
+
+interface PostData {
+  id: number
+  title: string
+  content: string
+  growth_record_id: number
+  category_id: number
+  destination_type: 'public_post' | 'friends_only' | 'private_post'
+}
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+  editData?: PostData
+  preselectedGrowthRecordId?: number
+}
+
+export default function CreatePostModal({ 
+  isOpen, 
+  onClose, 
+  onSuccess, 
+  editData, 
+  preselectedGrowthRecordId 
+}: Props) {
+  const { token } = useAuth()
+  const [growthRecords, setGrowthRecords] = useState<GrowthRecord[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // フォーム状態
+  const [formData, setFormData] = useState({
+    title: '',
+    content: '',
+    growth_record_id: preselectedGrowthRecordId?.toString() || '',
+    category_id: '',
+    destination_type: 'public_post' as 'public_post' | 'friends_only' | 'private_post'
+  })
+
+  // データ取得とフォーム初期化
+  useEffect(() => {
+    if (isOpen) {
+      fetchGrowthRecords()
+      fetchCategories()
+      
+      // 編集モードの場合、初期値を設定
+      if (editData) {
+        setFormData({
+          title: editData.title,
+          content: editData.content,
+          growth_record_id: editData.growth_record_id.toString(),
+          category_id: editData.category_id.toString(),
+          destination_type: editData.destination_type
+        })
+      } else if (preselectedGrowthRecordId) {
+        // 成長記録が事前選択されている場合
+        setFormData(prev => ({
+          ...prev,
+          growth_record_id: preselectedGrowthRecordId.toString()
+        }))
+      }
+    }
+  }, [isOpen, editData, preselectedGrowthRecordId])
+
+  const fetchGrowthRecords = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/growth_records?per_page=100`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        }
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        setGrowthRecords(data.growth_records || [])
+      }
+    } catch (err) {
+      console.error('Error fetching growth records:', err)
+    }
+  }, [token])
+
+  const fetchCategories = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/categories`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        setCategories(data.categories || [])
+      }
+    } catch (err) {
+      console.error('Error fetching categories:', err)
+    }
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+
+    try {
+      const isEditMode = !!editData
+      const url = isEditMode 
+        ? `${API_BASE_URL}/api/v1/posts/${editData.id}`
+        : `${API_BASE_URL}/api/v1/posts`
+      
+      const method = isEditMode ? 'PUT' : 'POST'
+
+      const response = await fetch(url, {
+        method: method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          post: {
+            title: formData.title,
+            content: formData.content,
+            growth_record_id: parseInt(formData.growth_record_id),
+            category_id: parseInt(formData.category_id),
+            destination_type: formData.destination_type
+          }
+        })
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || `投稿の${isEditMode ? '更新' : '作成'}に失敗しました`)
+      }
+
+      // 成功時
+      onSuccess()
+      handleClose()
+    } catch (err) {
+      console.error(`Error ${editData ? 'updating' : 'creating'} post:`, err)
+      setError(err instanceof Error ? err.message : `投稿の${editData ? '更新' : '作成'}に失敗しました`)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setFormData({
+      title: '',
+      content: '',
+      growth_record_id: preselectedGrowthRecordId?.toString() || '',
+      category_id: '',
+      destination_type: 'public_post'
+    })
+    setError(null)
+    onClose()
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }))
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50 p-4">
+      <div 
+        className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-6">
+          <div className="flex justify-between items-center mb-6">
+            <h2 className="text-xl font-bold text-gray-900">
+              {editData ? '投稿を編集' : '新しい投稿'}
+            </h2>
+            <button
+              onClick={handleClose}
+              className="text-gray-400 hover:text-gray-600 text-2xl"
+            >
+              ×
+            </button>
+          </div>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* 成長記録選択 */}
+            <div>
+              <label htmlFor="growth_record_id" className="block text-sm font-medium text-gray-700 mb-2">
+                成長記録 <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="growth_record_id"
+                name="growth_record_id"
+                value={formData.growth_record_id}
+                onChange={handleInputChange}
+                required
+                disabled={!!preselectedGrowthRecordId}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent disabled:bg-gray-100"
+              >
+                <option value="">成長記録を選択してください</option>
+                {growthRecords.map((record) => (
+                  <option key={record.id} value={record.id}>
+                    {record.plant.name} - {record.record_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* カテゴリ選択 */}
+            <div>
+              <label htmlFor="category_id" className="block text-sm font-medium text-gray-700 mb-2">
+                カテゴリ <span className="text-red-500">*</span>
+              </label>
+              <select
+                id="category_id"
+                name="category_id"
+                value={formData.category_id}
+                onChange={handleInputChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              >
+                <option value="">カテゴリを選択してください</option>
+                {categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* タイトル */}
+            <div>
+              <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
+                タイトル <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                id="title"
+                name="title"
+                value={formData.title}
+                onChange={handleInputChange}
+                required
+                maxLength={100}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                placeholder="タイトルを入力してください"
+              />
+            </div>
+
+            {/* 内容 */}
+            <div>
+              <label htmlFor="content" className="block text-sm font-medium text-gray-700 mb-2">
+                内容 <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                id="content"
+                name="content"
+                value={formData.content}
+                onChange={handleInputChange}
+                required
+                rows={6}
+                maxLength={1000}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent resize-none"
+                placeholder="投稿内容を入力してください"
+              />
+              <div className="text-right text-sm text-gray-500 mt-1">
+                {formData.content.length}/1000
+              </div>
+            </div>
+
+            {/* 公開範囲 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                公開範囲
+              </label>
+              <div className="space-y-2">
+                <label className="flex items-center">
+                  <input
+                    type="radio"
+                    name="destination_type"
+                    value="public_post"
+                    checked={formData.destination_type === 'public_post'}
+                    onChange={handleInputChange}
+                    className="mr-2"
+                  />
+                  <span className="text-sm">公開（全ユーザーが閲覧可能）</span>
+                </label>
+                <label className="flex items-center">
+                  <input
+                    type="radio"
+                    name="destination_type"
+                    value="friends_only"
+                    checked={formData.destination_type === 'friends_only'}
+                    onChange={handleInputChange}
+                    className="mr-2"
+                  />
+                  <span className="text-sm">フレンドのみ</span>
+                </label>
+                <label className="flex items-center">
+                  <input
+                    type="radio"
+                    name="destination_type"
+                    value="private_post"
+                    checked={formData.destination_type === 'private_post'}
+                    onChange={handleInputChange}
+                    className="mr-2"
+                  />
+                  <span className="text-sm">非公開（自分のみ）</span>
+                </label>
+              </div>
+            </div>
+
+            {/* ボタン */}
+            <div className="flex justify-end space-x-3">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={loading}
+                className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+              >
+                {loading ? (editData ? '更新中...' : '投稿中...') : (editData ? '更新する' : '投稿する')}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -22,9 +22,9 @@ interface PostData {
   id: number
   title: string
   content: string
-  growth_record_id: number
+  growth_record_id?: number
   category_id: number
-  destination_type: 'public_post' | 'friends_only' | 'private_post'
+  post_type: 'growth_record_post' | 'general_post'
 }
 
 interface Props {
@@ -54,7 +54,7 @@ export default function CreatePostModal({
     content: '',
     growth_record_id: preselectedGrowthRecordId?.toString() || '',
     category_id: '',
-    destination_type: 'public_post' as 'public_post' | 'friends_only' | 'private_post'
+    post_type: 'growth_record_post' as 'growth_record_post' | 'general_post'
   })
 
   // データ取得とフォーム初期化
@@ -68,15 +68,16 @@ export default function CreatePostModal({
         setFormData({
           title: editData.title,
           content: editData.content,
-          growth_record_id: editData.growth_record_id.toString(),
+          growth_record_id: editData.growth_record_id?.toString() || '',
           category_id: editData.category_id.toString(),
-          destination_type: editData.destination_type
+          post_type: editData.post_type
         })
       } else if (preselectedGrowthRecordId) {
         // 成長記録が事前選択されている場合
         setFormData(prev => ({
           ...prev,
-          growth_record_id: preselectedGrowthRecordId.toString()
+          growth_record_id: preselectedGrowthRecordId.toString(),
+          post_type: 'growth_record_post'
         }))
       }
     }
@@ -142,9 +143,9 @@ export default function CreatePostModal({
           post: {
             title: formData.title,
             content: formData.content,
-            growth_record_id: parseInt(formData.growth_record_id),
+            growth_record_id: formData.growth_record_id ? parseInt(formData.growth_record_id) : null,
             category_id: parseInt(formData.category_id),
-            destination_type: formData.destination_type
+            post_type: formData.post_type
           }
         })
       })
@@ -171,7 +172,7 @@ export default function CreatePostModal({
       content: '',
       growth_record_id: preselectedGrowthRecordId?.toString() || '',
       category_id: '',
-      destination_type: 'public_post'
+      post_type: 'growth_record_post'
     })
     setError(null)
     onClose()
@@ -179,10 +180,20 @@ export default function CreatePostModal({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target
-    setFormData(prev => ({
-      ...prev,
-      [name]: value
-    }))
+    
+    // 投稿タイプが変更された場合、成長記録をリセット
+    if (name === 'post_type') {
+      setFormData(prev => ({
+        ...prev,
+        post_type: value as 'growth_record_post' | 'general_post',
+        growth_record_id: value === 'general_post' ? '' : prev.growth_record_id
+      }))
+    } else {
+      setFormData(prev => ({
+        ...prev,
+        [name]: value
+      }))
+    }
   }
 
   if (!isOpen) return null
@@ -213,28 +224,63 @@ export default function CreatePostModal({
           )}
 
           <form onSubmit={handleSubmit} className="space-y-6">
-            {/* 成長記録選択 */}
+            {/* 投稿タイプ選択 */}
             <div>
-              <label htmlFor="growth_record_id" className="block text-sm font-medium text-gray-700 mb-2">
-                成長記録 <span className="text-red-500">*</span>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                投稿タイプ <span className="text-red-500">*</span>
               </label>
-              <select
-                id="growth_record_id"
-                name="growth_record_id"
-                value={formData.growth_record_id}
-                onChange={handleInputChange}
-                required
-                disabled={!!preselectedGrowthRecordId}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent disabled:bg-gray-100"
-              >
-                <option value="">成長記録を選択してください</option>
-                {growthRecords.map((record) => (
-                  <option key={record.id} value={record.id}>
-                    {record.plant.name} - {record.record_name}
-                  </option>
-                ))}
-              </select>
+              <div className="space-y-2">
+                <label className="flex items-center">
+                  <input
+                    type="radio"
+                    name="post_type"
+                    value="growth_record_post"
+                    checked={formData.post_type === 'growth_record_post'}
+                    onChange={handleInputChange}
+                    disabled={!!preselectedGrowthRecordId}
+                    className="mr-2"
+                  />
+                  <span className="text-sm">🌱 成長記録として投稿（成長記録 + タイムライン）</span>
+                </label>
+                <label className="flex items-center">
+                  <input
+                    type="radio"
+                    name="post_type"
+                    value="general_post"
+                    checked={formData.post_type === 'general_post'}
+                    onChange={handleInputChange}
+                    disabled={!!preselectedGrowthRecordId}
+                    className="mr-2"
+                  />
+                  <span className="text-sm">💬 雑談として投稿（タイムラインのみ）</span>
+                </label>
+              </div>
             </div>
+
+            {/* 成長記録選択（成長記録投稿の場合のみ表示） */}
+            {formData.post_type === 'growth_record_post' && (
+              <div>
+                <label htmlFor="growth_record_id" className="block text-sm font-medium text-gray-700 mb-2">
+                  成長記録 <span className="text-red-500">*</span>
+                </label>
+                <select
+                  id="growth_record_id"
+                  name="growth_record_id"
+                  value={formData.growth_record_id}
+                  onChange={handleInputChange}
+                  required
+                  disabled={!!preselectedGrowthRecordId}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent disabled:bg-gray-100"
+                >
+                  <option value="">成長記録を選択してください</option>
+                  {growthRecords.map((record) => (
+                    <option key={record.id} value={record.id}>
+                      {record.plant.name} - {record.record_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             {/* カテゴリ選択 */}
             <div>
@@ -297,47 +343,6 @@ export default function CreatePostModal({
               </div>
             </div>
 
-            {/* 公開範囲 */}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                公開範囲
-              </label>
-              <div className="space-y-2">
-                <label className="flex items-center">
-                  <input
-                    type="radio"
-                    name="destination_type"
-                    value="public_post"
-                    checked={formData.destination_type === 'public_post'}
-                    onChange={handleInputChange}
-                    className="mr-2"
-                  />
-                  <span className="text-sm">公開（全ユーザーが閲覧可能）</span>
-                </label>
-                <label className="flex items-center">
-                  <input
-                    type="radio"
-                    name="destination_type"
-                    value="friends_only"
-                    checked={formData.destination_type === 'friends_only'}
-                    onChange={handleInputChange}
-                    className="mr-2"
-                  />
-                  <span className="text-sm">フレンドのみ</span>
-                </label>
-                <label className="flex items-center">
-                  <input
-                    type="radio"
-                    name="destination_type"
-                    value="private_post"
-                    checked={formData.destination_type === 'private_post'}
-                    onChange={handleInputChange}
-                    className="mr-2"
-                  />
-                  <span className="text-sm">非公開（自分のみ）</span>
-                </label>
-              </div>
-            </div>
 
             {/* ボタン */}
             <div className="flex justify-end space-x-3">

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -144,7 +144,7 @@ export default function CreatePostModal({
             title: formData.title,
             content: formData.content,
             growth_record_id: formData.growth_record_id ? parseInt(formData.growth_record_id) : null,
-            category_id: parseInt(formData.category_id),
+            category_id: formData.post_type === 'growth_record_post' ? parseInt(formData.category_id) : null,
             post_type: formData.post_type
           }
         })
@@ -181,12 +181,13 @@ export default function CreatePostModal({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target
     
-    // 投稿タイプが変更された場合、成長記録をリセット
+    // 投稿タイプが変更された場合、成長記録とカテゴリをリセット
     if (name === 'post_type') {
       setFormData(prev => ({
         ...prev,
         post_type: value as 'growth_record_post' | 'general_post',
-        growth_record_id: value === 'general_post' ? '' : prev.growth_record_id
+        growth_record_id: value === 'general_post' ? '' : prev.growth_record_id,
+        category_id: value === 'general_post' ? '' : prev.category_id
       }))
     } else {
       setFormData(prev => ({
@@ -199,7 +200,14 @@ export default function CreatePostModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50 p-4">
+    <div 
+      className="fixed inset-0 flex items-center justify-center z-50 p-4"
+      style={{
+        backgroundColor: 'rgba(0, 0, 0, 0.3)',
+        backdropFilter: 'brightness(0.7)'
+      }}
+      onClick={handleClose}
+    >
       <div 
         className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
@@ -282,27 +290,29 @@ export default function CreatePostModal({
               </div>
             )}
 
-            {/* カテゴリ選択 */}
-            <div>
-              <label htmlFor="category_id" className="block text-sm font-medium text-gray-700 mb-2">
-                カテゴリ <span className="text-red-500">*</span>
-              </label>
-              <select
-                id="category_id"
-                name="category_id"
-                value={formData.category_id}
-                onChange={handleInputChange}
-                required
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
-              >
-                <option value="">カテゴリを選択してください</option>
-                {categories.map((category) => (
-                  <option key={category.id} value={category.id}>
-                    {category.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            {/* カテゴリ選択（成長記録投稿の場合のみ表示） */}
+            {formData.post_type === 'growth_record_post' && (
+              <div>
+                <label htmlFor="category_id" className="block text-sm font-medium text-gray-700 mb-2">
+                  カテゴリ <span className="text-red-500">*</span>
+                </label>
+                <select
+                  id="category_id"
+                  name="category_id"
+                  value={formData.category_id}
+                  onChange={handleInputChange}
+                  required
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                >
+                  <option value="">カテゴリを選択してください</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             {/* タイトル */}
             <div>

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -10,12 +10,13 @@ interface Post {
   id: number
   title: string
   content: string
+  post_type: 'growth_record_post' | 'general_post'
   created_at: string
   user: {
     id: number
     name: string
   }
-  growth_record: {
+  growth_record?: {
     id: number
     record_name: string
     plant: {

--- a/frontend/src/components/timeline/Timeline.tsx
+++ b/frontend/src/components/timeline/Timeline.tsx
@@ -24,7 +24,7 @@ interface Post {
       name: string
     }
   }
-  category: {
+  category?: {
     id: number
     name: string
   }
@@ -137,19 +137,6 @@ export default function Timeline() {
 
   return (
     <div className="space-y-4">
-      {/* 投稿作成ボタン（ログインユーザーのみ表示） */}
-      {user && (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-          <button
-            onClick={() => setIsCreateModalOpen(true)}
-            className="w-full py-3 px-4 bg-green-500 hover:bg-green-600 text-white font-semibold rounded-lg transition-colors flex items-center justify-center"
-          >
-            <span className="text-lg mr-2">✏️</span>
-            新しい投稿を作成
-          </button>
-        </div>
-      )}
-
       {/* 投稿一覧 */}
       <div>
         {posts.map((post, index) => (
@@ -173,6 +160,18 @@ export default function Timeline() {
           </div>
         )}
       </div>
+
+      {/* Floating Action Button（ログインユーザーのみ表示） */}
+      {user && (
+        <button
+          onClick={() => setIsCreateModalOpen(true)}
+          className="fixed bottom-20 right-4 w-14 h-14 bg-green-500 hover:bg-green-600 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-200 flex items-center justify-center z-40"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+        </button>
+      )}
 
       {/* 投稿作成モーダル */}
       <CreatePostModal

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -6,12 +6,13 @@ interface TimelinePostProps {
     id: number
     title: string
     content: string
+    post_type: 'growth_record_post' | 'general_post'
     created_at: string
     user: {
       id: number
       name: string
     }
-    growth_record: {
+    growth_record?: {
       id: number
       record_name: string
       plant: {
@@ -62,18 +63,35 @@ export default function TimelinePost({ post }: TimelinePostProps) {
         </p>
       </div>
 
-      {/* 画像プレースホルダー */}
+      {/* 投稿タイプ表示と成長記録情報 */}
       <div className="mb-4">
-        <div className="w-full h-64 bg-gray-200 rounded-lg flex items-center justify-center">
-          <div className="text-center">
-            <div className="w-16 h-16 bg-green-200 rounded mx-auto mb-2 flex items-center justify-center">
-              <svg className="w-8 h-8 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
-              </svg>
-            </div>
-            <p className="text-sm text-gray-500">{post.growth_record.plant.name}</p>
-          </div>
+        <div className="flex items-center space-x-2 mb-2">
+          <span className={`px-2 py-1 rounded-full text-xs font-medium ${
+            post.post_type === 'growth_record_post' 
+              ? 'bg-green-100 text-green-800' 
+              : 'bg-blue-100 text-blue-800'
+          }`}>
+            {post.post_type === 'growth_record_post' ? '🌱 成長記録' : '💬 雑談'}
+          </span>
+          <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
+            {post.category.name}
+          </span>
         </div>
+        
+        {/* 成長記録がある場合の画像プレースホルダー */}
+        {post.growth_record && (
+          <div className="w-full h-64 bg-gray-200 rounded-lg flex items-center justify-center">
+            <div className="text-center">
+              <div className="w-16 h-16 bg-green-200 rounded mx-auto mb-2 flex items-center justify-center">
+                <svg className="w-8 h-8 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <p className="text-sm text-gray-500">{post.growth_record.plant.name}</p>
+              <p className="text-xs text-gray-400">{post.growth_record.record_name}</p>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* アクションボタン */}

--- a/frontend/src/components/timeline/TimelinePost.tsx
+++ b/frontend/src/components/timeline/TimelinePost.tsx
@@ -20,7 +20,7 @@ interface TimelinePostProps {
         name: string
       }
     }
-    category: {
+    category?: {
       id: number
       name: string
     }
@@ -73,9 +73,11 @@ export default function TimelinePost({ post }: TimelinePostProps) {
           }`}>
             {post.post_type === 'growth_record_post' ? '🌱 成長記録' : '💬 雑談'}
           </span>
-          <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
-            {post.category.name}
-          </span>
+          {post.post_type === 'growth_record_post' && post.category && (
+            <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs">
+              {post.category.name}
+            </span>
+          )}
         </div>
         
         {/* 成長記録がある場合の画像プレースホルダー */}
@@ -135,8 +137,15 @@ export default function TimelinePost({ post }: TimelinePostProps) {
 
       {/* ログインモーダル */}
       {showLoginModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 m-4 max-w-sm w-full">
+        <div 
+          className="fixed inset-0 flex items-center justify-center z-50"
+          style={{
+            backgroundColor: 'rgba(0, 0, 0, 0.3)',
+            backdropFilter: 'brightness(0.7)'
+          }}
+          onClick={() => setShowLoginModal(false)}
+        >
+          <div className="bg-white rounded-lg p-6 m-4 max-w-sm w-full" onClick={(e) => e.stopPropagation()}>
             <h2 className="text-lg font-semibold mb-4 text-center">ログインが必要です</h2>
             <p className="text-gray-600 mb-6 text-center">
               投稿へのいいね、コメント、シェアを行うにはログインが必要です。


### PR DESCRIPTION
### 概要
  投稿作成機能の実装とUI改善。投稿タイプ（成長記録投稿/雑談投稿）に対応し、条件付きカテゴリ表示を実装。

  ### 変更内容
  - 投稿作成API（CRUD操作）実装
  - 投稿タイプ別UI実装（成長記録投稿/雑談投稿）
  - 条件付きカテゴリ表示（成長記録投稿のみカテゴリバッジ表示）
  - category_idをオプショナル化（雑談投稿対応）
  - フッター投稿ボタン削除
  - タイムラインFloating Action Button追加
  - API応答でnullカテゴリ対応
  - 投稿作成モーダルの条件付きカテゴリ選択

### 関連Issue
<!-- 関連するIssueがあれば -->
#59 #61 
### CloseしたいIssue
Close #59 Close #61 