### PR TITLE
refactor: アプリ・機能名の標準化とUI調整

### DIFF
--- a/backend/config/initializers/filter_parameter_logging.rb
+++ b/backend/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,4 @@
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,6 +25,11 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* スクロールバーによるレイアウトシフトを防ぐ */
+html {
+  overflow-y: scroll;
+}
+
 /* アプリ全体で使用する薄緑背景のユーティリティクラス */
 .bg-app {
   background: #89FD8B33;

--- a/frontend/src/app/growth-records/page.tsx
+++ b/frontend/src/app/growth-records/page.tsx
@@ -33,7 +33,7 @@ export default function GrowthRecordsPage() {
     <div className="flex justify-center">
       <div className="w-full max-w-2xl min-w-80 px-4 py-6">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 mb-2">ベジログ</h1>
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">成長記録</h1>
         <p className="text-gray-600">あなたの成長記録一覧</p>
       </div>
       

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,7 +6,7 @@ import LayoutWrapper from '@/components/layout/LayoutWrapper'
 import FlashMessages from '@/components/ui/FlashMessages'
 
 export const metadata = {
-  title: 'ベジファミリー',
+  title: 'おうちの畑',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/components/growth-records/GrowthRecordDetail.tsx
+++ b/frontend/src/components/growth-records/GrowthRecordDetail.tsx
@@ -262,18 +262,18 @@ export default function GrowthRecordDetail({ id }: Props) {
         </div>
       </div>
 
-      {/* 関連投稿 */}
+      {/* 成長メモ */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold text-gray-900">
-            関連投稿 ({posts.length}件)
+            成長メモ ({posts.length}件)
           </h2>
           {user && user.id === growthRecord.user.id && (
             <button
               onClick={() => setIsCreatePostModalOpen(true)}
               className="px-4 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-md transition-colors"
             >
-              ＋ 投稿を作成
+              ＋ 成長メモを作成
             </button>
           )}
         </div>

--- a/frontend/src/components/layout/AuthenticatedFooter.tsx
+++ b/frontend/src/components/layout/AuthenticatedFooter.tsx
@@ -14,12 +14,12 @@ export default function AuthenticatedFooter() {
             <span className="text-xs">ホーム</span>
           </Link>
           
-          {/* ベジログ */}
+          {/* 成長記録 */}
           <Link href="/growth-records" className="flex flex-col items-center space-y-1">
             <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm0 4a1 1 0 011-1h12a1 1 0 011 1v8a1 1 0 01-1 1H4a1 1 0 01-1-1V8zm4 4a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
             </svg>
-            <span className="text-xs">ベジログ</span>
+            <span className="text-xs">成長記録</span>
           </Link>
           
           {/* 育て方指南 */}

--- a/frontend/src/components/layout/AuthenticatedHeader.tsx
+++ b/frontend/src/components/layout/AuthenticatedHeader.tsx
@@ -12,7 +12,7 @@ export default function AuthenticatedHeader() {
     <header className="fixed top-0 left-0 right-0 bg-[#6AF484] p-4 shadow z-50">
       <div className="flex justify-center">
         <nav className="w-full max-w-2xl min-w-80 flex items-center justify-between px-4">
-        <Link href="/" className="font-medium">🌱 Vegetamily</Link>
+        <Link href="/" className="text-xl font-black tracking-wide font-serif">🌱 おうちの畑</Link>
         
         <div className="flex items-center space-x-3">
           {/* 通知 */}

--- a/frontend/src/components/layout/PublicHeader.tsx
+++ b/frontend/src/components/layout/PublicHeader.tsx
@@ -7,7 +7,7 @@ export default function PublicHeader() {
     <header className="fixed top-0 left-0 right-0 bg-[#6AF484] p-4 shadow z-50">
       <div className="flex justify-center">
         <nav className="w-full max-w-2xl min-w-80 flex items-center px-4">
-        <Link href="/" className="font-medium pl-6">ホーム</Link>
+        <Link href="/" className="text-xl font-black pl-6 tracking-wide font-serif">🌱 おうちの畑</Link>
         <div className="ml-auto flex space-x-6 pr-6">
           <Link href="/how-to-use" className="font-medium">使い方</Link>
           <Link href="/login" className="font-medium">ログイン</Link>

--- a/frontend/src/components/posts/CreatePostModal.tsx
+++ b/frontend/src/components/posts/CreatePostModal.tsx
@@ -237,7 +237,7 @@ export default function CreatePostModal({
                     disabled={!!preselectedGrowthRecordId}
                     className="mr-2"
                   />
-                  <span className="text-sm">🌱 成長記録として投稿（成長記録 + タイムライン）</span>
+                  <span className="text-sm">🌱 成長メモ（成長メモ + タイムライン）</span>
                 </label>
                 {!preselectedGrowthRecordId && (
                   <label className="flex items-center">
@@ -249,7 +249,7 @@ export default function CreatePostModal({
                       onChange={handleInputChange}
                       className="mr-2"
                     />
-                    <span className="text-sm">💬 雑談として投稿（タイムラインのみ）</span>
+                    <span className="text-sm">💬 雑談（タイムラインのみ）</span>
                   </label>
                 )}
               </div>
@@ -341,7 +341,7 @@ export default function CreatePostModal({
                 disabled={loading}
                 className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
               >
-                {loading ? (editData ? '更新中...' : '投稿中...') : (editData ? '更新する' : '投稿する')}
+                {loading ? (editData ? '更新中...' : '作成中...') : (editData ? '更新する' : '作成する')}
               </button>
             </div>
           </form>


### PR DESCRIPTION
### 概要
  開発中の仮名称から正式なアプリ・機能名への標準化とUI改善を実施

  ### 変更内容
  - アプリ名を「ベジファミリー/そだてーる」から「おうちの畑」に統一
  - 主要機能名を「ベジログ」から「成長記録」に変更
  - 成長記録詳細ページの「関連投稿」を「成長メモ」に変更
  - 投稿モーダルの「日記タイプ」を「投稿タイプ」に修正
  - 投稿作成ボタンを「+ 投稿を作成」から「+ 成長メモを作成」に変更
  - 投稿タイプの説明文を簡潔化（「雑談として投稿」→「雑談」）
  - ログイン前後のヘッダーフォントを明朝体・太字で統一
  - スクロールバーによるレイアウトシフトを修正